### PR TITLE
small cmake fix

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,15 +5,15 @@
     "board/esp32s3-builtin.cfg"
   ],
   "idf.port": "/dev/ttyACM0",
-  "idf.toolsPath": "/home/jpowen/.espressif",
+  "idf.toolsPath": "${userHome}/.espressif",
   "idf.customExtraVars": {
     "IDF_TARGET": "esp32s3"
   },
-  "clangd.path": "/home/jpowen/.espressif/tools/esp-clang/esp-19.1.2_20250312/esp-clang/bin/clangd",
+  "clangd.path": "${userHome}/.espressif/tools/esp-clang/esp-19.1.2_20250312/esp-clang/bin/clangd",
   "clangd.arguments": [
     "--background-index",
-    "--query-driver=/home/jpowen/.espressif/tools/xtensa-esp-elf/esp-14.2.0_20241119/xtensa-esp-elf/bin/xtensa-esp32s3-elf-gcc",
-    "--compile-commands-dir=/home/jpowen/dev/esp_knob/spotify_app/build"
+    "--query-driver=${userHome}/.espressif/tools/xtensa-esp-elf/esp-14.2.0_20241119/xtensa-esp-elf/bin/xtensa-esp32s3-elf-gcc",
+    "--compile-commands-dir=${userHome}/dev/esp_knob/spotify_app/build"
   ],
   "idf.flashType": "UART",
   "editor.formatOnSave": true,

--- a/components/ui/CMakeLists.txt
+++ b/components/ui/CMakeLists.txt
@@ -2,7 +2,6 @@
 file(GLOB UI_SRCS
     "generated/*.c"
     "generated/components/*.c"
-    "generated/fonts/*.c"
     "generated/images/*.c"
     "generated/screens/*.c"
 )
@@ -21,7 +20,6 @@ idf_component_register(
         "."
         "generated/"
         "generated/components/"
-        "generated/fonts/"
         "generated/images/"
         "generated/screens/"
 )


### PR DESCRIPTION
hey! Cool project. Motivated me to buy one of the dials for a different project i have in mind. I'm planning to use this as a jumping off point since it has a lot of the core functions I'll be needing.

This is a minor cmake fix i needed to get my local build working. I'm not sure if the `generated/fonts` dir is supposed to exist. The project builds without it and text is displayed on screen. But i dont have a Spotify account so i cant test thoroughly.

thanks for putting this out there!